### PR TITLE
Eco system / budget optimization

### DIFF
--- a/common/decisions/_generic_decisions.txt
+++ b/common/decisions/_generic_decisions.txt
@@ -1190,7 +1190,7 @@ eoanb_category_economic = {
 				has_idea = bankruptcy
 			}
 			has_taken_a_loan = yes
-			calculate_money_balance = yes
+			#calculate_money_balance = yes
 			set_temp_variable = {
 				required_income = expenses_from_loans
 			}
@@ -1208,7 +1208,7 @@ eoanb_category_economic = {
 				has_idea = bankruptcy
 			}
 			has_taken_a_loan = yes
-			calculate_money_balance = yes
+			#calculate_money_balance = yes
 			set_temp_variable = {
 				required_income = expenses_from_loans
 			}
@@ -1222,7 +1222,7 @@ eoanb_category_economic = {
 			}
 		}
 		available = {
-			calculate_money_balance = yes
+			#calculate_money_balance = yes
 			set_temp_variable = {
 				required_income = expenses_from_loans
 			}
@@ -1262,7 +1262,7 @@ eoanb_category_economic = {
 			}
 			has_war = yes
 			has_taken_a_loan = yes
-			calculate_money_balance = yes
+			#calculate_money_balance = yes
 			set_temp_variable = {
 				required_income = expenses_from_loans
 			}
@@ -1281,7 +1281,7 @@ eoanb_category_economic = {
 			}
 			has_war = yes
 			has_taken_a_loan = yes
-			calculate_money_balance = yes
+			#calculate_money_balance = yes
 			set_temp_variable = {
 				required_income = expenses_from_loans
 			}
@@ -1295,7 +1295,7 @@ eoanb_category_economic = {
 			}
 		}
 		available = {
-			calculate_money_balance = yes
+			#calculate_money_balance = yes
 			set_temp_variable = {
 				required_income = expenses_from_loans
 			}

--- a/common/ideas/_Money_System.txt
+++ b/common/ideas/_Money_System.txt
@@ -150,7 +150,7 @@ ideas = {
 				base = 1
 				modifier = {
 					factor = 1000
-					calculate_money_balance = yes
+					#calculate_money_balance = yes
 					check_variable = { total_balance_temp > 50 }
 					has_idea = research_spending_level_5
 					has_idea = taxation_level_3
@@ -686,7 +686,7 @@ ideas = {
 				modifier = {
 					factor = 2000
 					has_idea = research_spending_level_4
-					calculate_money_balance = yes
+					#calculate_money_balance = yes
 					check_variable = { total_balance_temp > 5 }
 				}
 				modifier = {
@@ -889,7 +889,7 @@ ideas = {
 					has_war = yes
 					OR = {
 						AND = {
-							calculate_money_balance = yes
+							#calculate_money_balance = yes
 							check_variable = { total_balance_temp > 25 }
 						}
 						is_major = yes

--- a/common/on_actions/_on_startup_events.txt
+++ b/common/on_actions/_on_startup_events.txt
@@ -88,6 +88,25 @@ on_actions = {
 					}
 					add_ideas = law_spending_level_3
 				}
+				
+				if = {
+					limit = {
+						NOT = {
+							has_country_flag = Country_Optimised	#Blacklist or Whitelist (performance is better for whitelist)
+						}
+					}
+					if = {
+						limit = {
+							calculate_money_balance = yes # calculates the money
+							always = yes
+						}
+						# update static vars
+						# this is kinda tarded but it works
+						set_variable = { total_income_temp = total_income_temp }
+						set_variable = { total_expenses_temp = total_expenses_temp }
+						set_variable = { total_balance_temp = total_balance_temp }
+					}
+				}
 			}
 			#every_country = {
 			#	pop_state_update = yes

--- a/common/on_actions/on_monthly.txt
+++ b/common/on_actions/on_monthly.txt
@@ -225,6 +225,12 @@ on_actions = {
 					clr_country_flag = eoanb_is_bankrolling
 					clear_variable = bankrolled_giving
 				}
+				
+				# update static vars
+				# this is kinda tarded but it works
+				set_variable = { total_income_temp = total_income_temp }
+				set_variable = { total_expenses_temp = total_expenses_temp }
+				set_variable = { total_balance_temp = total_balance_temp }
 			}
 			if = {
 				limit = {

--- a/common/scripted_guis/_Money_scripted_gui.txt
+++ b/common/scripted_guis/_Money_scripted_gui.txt
@@ -12,8 +12,8 @@ scripted_gui = {
 				limit = {
 					is_ai = no
 				}
-				calculate_money_balance = yes
-				calculate_inflation_change = yes
+				#calculate_money_balance = yes
+				#calculate_inflation_change = yes
 			}
 			set_temp_variable = { balance_indicator_icon_frame = 1 }
 			if = {
@@ -51,13 +51,13 @@ scripted_gui = {
 
 		visible = {
 			always = yes
-			if = {
-				limit = {
-					is_ai = no
-				}
-				calculate_money_balance = yes
-				calculate_inflation_change = yes
-			}
+			#if = {
+			#	limit = {
+			#		is_ai = no
+			#	}
+			#	calculate_money_balance = yes
+			#	calculate_inflation_change = yes
+			#}
 			set_temp_variable = { balance_indicator_icon_frame = 1 }
 			if = {
 				limit = {
@@ -76,6 +76,9 @@ scripted_gui = {
 		triggers = {
 			balance_indicator_icon_visible = {
 				is_ai = no
+				
+				calculate_money_balance = yes
+				calculate_inflation_change = yes
 			}
 		}
 
@@ -135,16 +138,20 @@ scripted_gui = {
 
 		visible = {
 			OR = {
-				is_ai = yes
+				# this might be a problem if the UI is open for AI all the time
+				#is_ai = yes
 				check_variable = { show_economy_window > 0 }
 			}
-			if = {
-				limit = {
-					is_ai = no
-				}
-				calculate_money_balance = yes
-				calculate_inflation_change = yes
-			}
+			
+			# doing this here very bad no good
+			# see pay_loan_button_visible
+			#if = {
+			#	limit = {
+			#		is_ai = no
+			#	}
+			#	calculate_money_balance = yes
+			#	calculate_inflation_change = yes
+			#}
 		}
 
 		effects = {
@@ -698,6 +705,14 @@ scripted_gui = {
 		}
 
 		triggers = {
+			# this will continually update the budget gui when it's open
+			# this could be any visible trigger on any element
+			# just don't put these into the overarching visible trigger of the window
+			pay_loan_button_visible = {
+				calculate_money_balance = yes
+				calculate_inflation_change = yes
+			}
+		
 			pay_loan_button_click_enabled = {
 				set_temp_variable = { loan_size = current_loans_sum }
 				if = {

--- a/common/scripted_guis/_Money_scripted_gui.txt
+++ b/common/scripted_guis/_Money_scripted_gui.txt
@@ -139,7 +139,7 @@ scripted_gui = {
 		visible = {
 			OR = {
 				# this might be a problem if the UI is open for AI all the time
-				#is_ai = yes
+				is_ai = yes
 				check_variable = { show_economy_window > 0 }
 			}
 			

--- a/common/scripted_guis/_Money_scripted_gui.txt
+++ b/common/scripted_guis/_Money_scripted_gui.txt
@@ -8,6 +8,8 @@ scripted_gui = {
 
 		visible = {
 			always = yes
+			
+			# topbar money stuff is supplied by monthly updated static vars
 			#if = {
 			#	limit = {
 			#		is_ai = no
@@ -15,6 +17,7 @@ scripted_gui = {
 			#	calculate_money_balance = yes
 			#	calculate_inflation_change = yes
 			#}
+			
 			set_temp_variable = { balance_indicator_icon_frame = 1 }
 			if = {
 				limit = {
@@ -51,6 +54,9 @@ scripted_gui = {
 
 		visible = {
 			always = yes
+			
+			# doing this here very bad no good
+			# see balance_indicator_icon_visible
 			#if = {
 			#	limit = {
 			#		is_ai = no
@@ -58,6 +64,7 @@ scripted_gui = {
 			#	calculate_money_balance = yes
 			#	calculate_inflation_change = yes
 			#}
+			
 			set_temp_variable = { balance_indicator_icon_frame = 1 }
 			if = {
 				limit = {
@@ -77,6 +84,7 @@ scripted_gui = {
 			balance_indicator_icon_visible = {
 				is_ai = no
 				
+				# I'm not sure if this if is needed here
 				if = {
 					limit = {
 						is_ai = no

--- a/common/scripted_guis/_Money_scripted_gui.txt
+++ b/common/scripted_guis/_Money_scripted_gui.txt
@@ -8,13 +8,13 @@ scripted_gui = {
 
 		visible = {
 			always = yes
-			if = {
-				limit = {
-					is_ai = no
-				}
-				#calculate_money_balance = yes
-				#calculate_inflation_change = yes
-			}
+			#if = {
+			#	limit = {
+			#		is_ai = no
+			#	}
+			#	calculate_money_balance = yes
+			#	calculate_inflation_change = yes
+			#}
 			set_temp_variable = { balance_indicator_icon_frame = 1 }
 			if = {
 				limit = {
@@ -77,8 +77,13 @@ scripted_gui = {
 			balance_indicator_icon_visible = {
 				is_ai = no
 				
-				calculate_money_balance = yes
-				calculate_inflation_change = yes
+				if = {
+					limit = {
+						is_ai = no
+					}
+					calculate_money_balance = yes
+					calculate_inflation_change = yes
+				}
 			}
 		}
 

--- a/common/scripted_triggers/_money_scripted_triggers.txt
+++ b/common/scripted_triggers/_money_scripted_triggers.txt
@@ -126,6 +126,8 @@ has_balance_in_negative = {
 # example usage:
 ## calculate_money_balance = yes
 calculate_money_balance = {
+	log = "[GetDateText] running calculate_money_balance for [THIS.GetName]"
+
 	set_temp_variable = { total_balance_temp = 0 }
 
 	# Income:
@@ -423,6 +425,8 @@ calculate_money_income_modifiers = {
 # example usage:
 ## calculate_money_expenses = yes
 calculate_money_expenses = {
+	log = "[GetDateText] running calculate_money_expenses for [THIS.GetName]"
+
 	set_temp_variable = { total_expenses_temp = 0 }
 
 	# Social Spending:


### PR DESCRIPTION
Carried over from https://github.com/EoaNB-Team/EoaNB/pull/37

- common/decisions/_generic_decisions.txt: print money missions need rework, they're probably broken as of now
	- notice the commented out "calculate_money_balance = yes"
	- these triggers are responsible for a lot of checks
- budget GUI (Financial Overview) is updated if the game is unpaused and the GUI open
	- read: don't let the AI open the budget GUI or it'll constantly be running all of those triggers again, consider just making some monthly events or missions or whatever that change spending, taxes and whatever else without going through the GUI
- temp vars turned to static vars:
	- total_income_temp, total_expenses_temp, total_balance_temp
	- static vars are set on startup for all countries without the Country_Optimised flag and then updated monthly, see common/on_actions/_on_startup_events.txt and common/on_actions/on_monthly.txt
	- notice that their name has not been changed so checking against them with check_variable will either pick up the static or the temp var, depending on the context (i.e. whether the temp var exists in the current scope)
- the tooltip of topbar_money_window_info::background (total treasury) is broken, and probably not worth the hassle to begin with, just get rid of it you have a whole custom UI for all of those numbers already
- notice that the monthly updated values in the topbar and the up-to-date values in the GUI will not be the same